### PR TITLE
Add criteria/criterionIds synonyms

### DIFF
--- a/src/main/java/org/cdisc/tools/GeneratorApp.java
+++ b/src/main/java/org/cdisc/tools/GeneratorApp.java
@@ -214,6 +214,9 @@ public class GeneratorApp {
         if (name.contains("children")){
             synonyms.add(name.replace("children", "child") + "Ids");
         }
+        if (name.contains("criteria")){
+            synonyms.add(name.replace("criteria", "criterion") + "Ids");
+        }
         return synonyms;
     }
 
@@ -232,6 +235,9 @@ public class GeneratorApp {
         }
         if (name.contains("child") && name.endsWith("Ids")){
             synonyms.add(name.substring(0, name.length() - "Ids".length()).replace("child", "children"));
+        }
+        if (name.contains("criterion") && name.endsWith("Ids")){
+            synonyms.add(name.substring(0, name.length() - "Ids".length()).replace("criterion", "criteria"));
         }
         return synonyms;
     }


### PR DESCRIPTION
Updated `toIds` and `fromIds` in GeneratorApp.java to add synonyms for criteria/criterionIds.